### PR TITLE
Disable drawing bold text with bright colors

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -32,3 +32,5 @@ colors:
     magenta: '0x{{base06-hex}}'
     cyan:    '0x{{base0F-hex}}'
     white:   '0x{{base07-hex}}'
+
+draw_bold_text_with_bright_colors: false


### PR DESCRIPTION
For non-256 variants, the bright colors are not actually bright, but
instead other colors. As such, disable drawing bold text with bright
colors to limit this impact.

This is not necessary for the 256 variants.